### PR TITLE
Issue 28 chore: redesign loss page

### DIFF
--- a/packages/react-frontend/src/App.css
+++ b/packages/react-frontend/src/App.css
@@ -174,68 +174,142 @@ footer {
   color: var(--secondary-color);
 }
 
-.loss-page {
-  text-align: center;
-  padding: 2rem 1rem;
+/* Loss Page Styles */
+/* ...existing code... */
+
+.loss-outer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 70vh;
+  padding: 2rem 0;
 }
 
 .loss-title {
-  font-size: 2rem;
+  font-size: 2.5rem;
+  font-weight: 800;
   color: var(--primary-color);
-  margin-bottom: 1rem;
-}
-
-.final-score {
-  font-size: 1.5rem;
-  color: var(--text-color);
   margin-bottom: 2rem;
+  letter-spacing: 0.01em;
+  text-align: center;
 }
 
-.loss-gif-placeholder {
+.loss-card {
+  background: white;
+  border-radius: 1.25rem;
+  box-shadow: var(--card-shadow);
+  padding: 2.5rem 2rem;
+  max-width: 480px;
   width: 100%;
-  max-width: 400px;
-  height: 200px;
-  background-color: var(--secondary-color);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2.5rem;
+}
+
+.loss-gif-large {
+  width: 100%;
+  max-width: 360px;
+  height: 240px;
+  background: var(--secondary-color);
   color: white;
   display: flex;
   align-items: center;
   justify-content: center;
-  margin: 0 auto 2rem;
-  border-radius: 0.5rem;
+  border-radius: 1rem;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.07);
+  font-size: 1.3rem;
+  font-weight: 500;
+  margin-bottom: 1.5rem;
 }
 
-.loss-buttons {
+.loss-score {
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.score-label {
+  font-size: 1.1rem;
+  color: var(--secondary-color);
+  margin-bottom: 0.25rem;
+  letter-spacing: 0.02em;
+}
+
+.score-value {
+  font-size: 2.8rem;
+  font-weight: 700;
+  color: var(--primary-color);
+  line-height: 1;
+}
+
+.loss-buttons-row {
+  display: flex;
+  gap: 1.25rem;
+  width: 100%;
+  justify-content: center;
 }
 
 .play-again-button,
 .back-home-button {
-  padding: 0.75rem 1.5rem;
-  font-size: 1rem;
+  flex: 1 1 0;
+  padding: 0.9rem 0;
+  font-size: 1.1rem;
   border: none;
-  border-radius: 0.25rem;
+  border-radius: 0.5rem;
   cursor: pointer;
-  transition: background-color 0.2s;
+  transition:
+    background 0.2s,
+    transform 0.2s;
+  font-weight: 600;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
 }
 
 .play-again-button {
-  background-color: var(--primary-color);
-  color: white;
+  background: var(--primary-color);
+  color: #fff;
 }
 
 .play-again-button:hover {
-  background-color: #1d4ed8;
+  background: #1d4ed8;
+  transform: translateY(-2px) scale(1.03);
 }
 
 .back-home-button {
-  background-color: var(--accent-color);
-  color: white;
+  background: var(--accent-color);
+  color: #fff;
 }
 
 .back-home-button:hover {
-  background-color: #d97706;
+  background: #d97706;
+  transform: translateY(-2px) scale(1.03);
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+  .loss-title {
+    font-size: 2rem;
+    margin-bottom: 1.2rem;
+  }
+  .loss-card {
+    padding: 1.25rem 0.5rem;
+    max-width: 98vw;
+    gap: 1.5rem;
+  }
+  .loss-gif-large {
+    max-width: 95vw;
+    height: 160px;
+    font-size: 1rem;
+  }
+  .score-value {
+    font-size: 2rem;
+  }
+  .loss-buttons-row {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
 }
 
 /* HOME PAGE STYLES */

--- a/packages/react-frontend/src/pages/LossPage.jsx
+++ b/packages/react-frontend/src/pages/LossPage.jsx
@@ -6,30 +6,36 @@ import { useGame } from "../context/GameContext";
 
 function LossPage() {
   const isMobile = useIsMobile();
-
   const navigate = useNavigate();
   const { score } = useGame();
 
   return (
     <Layout>
       <PageContainer>
-        <div className="loss-page">
+        <div className="loss-outer">
           <h1 className="loss-title">Game Over</h1>
-          <p className="final-score">Your score: {score}</p>
-          <div className="loss-gif-placeholder">
-            {isMobile
-              ? "GIF Placeholder (Mobile)"
-              : "GIF Placeholder (Desktop)"}
-          </div>
-          <div className="loss-buttons">
-            <button
-              className="play-again-button"
-              onClick={() => navigate("/game")}>
-              Play Again
-            </button>
-            <button className="back-home-button" onClick={() => navigate("/")}>
-              Back to Home
-            </button>
+          <div className="loss-card">
+            <div className="loss-gif-large">
+              {isMobile
+                ? "GIF Placeholder (Mobile)"
+                : "GIF Placeholder (Desktop)"}
+            </div>
+            <div className="loss-score">
+              <span className="score-label">Your score</span>
+              <span className="score-value">{score}</span>
+            </div>
+            <div className="loss-buttons-row">
+              <button
+                className="play-again-button"
+                onClick={() => navigate("/game")}>
+                Play Again
+              </button>
+              <button
+                className="back-home-button"
+                onClick={() => navigate("/")}>
+                Back to Home
+              </button>
+            </div>
           </div>
         </div>
       </PageContainer>


### PR DESCRIPTION
## Developer: Venkata G. Ande

Closes #28 

### Pull Request Summary

Enhance the Loss Page with a larger, more visually impactful GIF display.

### Modifications
in /react-frontend, I modified the following files:
- LossPage.jsx
- App.css

### Testing Considerations

I tried to keep a consistent design scheme.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our
      [guidelines](https://h4i.notion.site/Git-Commits-Pull-Requests-1-fd22949218fd4b4c976146a0d741b9bf)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast
LossPage.jsx changes:
![image](https://github.com/user-attachments/assets/0a4d8fef-1c3d-40f2-aa9c-f5aeb072c9e7)

App.css changes:
![image](https://github.com/user-attachments/assets/2a84eeb6-ee34-42bd-97a5-a6bed021141a)
