### PR TITLE
feat: Add Before/After overlay to provide user feedback on loss

### DIFF
--- a/packages/react-frontend/src/App.css
+++ b/packages/react-frontend/src/App.css
@@ -891,3 +891,62 @@ footer {
 .text-button:hover {
   color: #1d4ed8;
 }
+
+/* Issue 19 code */
+
+.result-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(0, 0, 0, 0.7);
+  z-index: 100;
+  opacity: 0;
+  transition: opacity 0.3s ease-in-out;
+  pointer-events: none;
+}
+
+.result-overlay.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.result-message {
+  font-size: 2rem;
+  color: white;
+  text-align: center;
+  padding: 2rem;
+  background: rgba(0, 0, 0, 0.5);
+  border-radius: 1rem;
+  transform: scale(0.8);
+  transition: transform 0.3s ease-in-out;
+}
+
+.result-overlay.visible .result-message {
+  transform: scale(1);
+}
+
+/* Issue 19 code: Card transition animations */
+.card {
+  transition: transform 0.5s ease-in-out;
+}
+
+.card-enter {
+  transform: translateX(100%);
+}
+
+.card-enter-active {
+  transform: translateX(0);
+}
+
+.card-exit {
+  transform: translateX(0);
+}
+
+.card-exit-active {
+  transform: translateX(-100%);
+}

--- a/packages/react-frontend/src/components/ResultOverlay.jsx
+++ b/packages/react-frontend/src/components/ResultOverlay.jsx
@@ -1,0 +1,41 @@
+import { useEffect } from "react";
+
+/**
+ * Display overlay with result of guess
+ * @param {Object} props
+ * @param {Boolean} props.visible - Whether overlay is visible
+ * @param {String} props.oldTitle - Title of reference card
+ * @param {String} props.newTitle - Title of compared card
+ * @param {String} props.relation - "Before" or "After"
+ * @param {Function} props.onAnimationComplete - Callback when animation finishes
+ */
+
+function ResultOverlay({
+  visible,
+  oldTitle,
+  newTitle,
+  relation,
+  onAnimationComplete
+}) {
+  useEffect(() => {
+    if (visible) {
+      const timer = setTimeout(() => {
+        onAnimationComplete && onAnimationComplete();
+      }, 1500);
+      return () => clearTimeout(timer);
+    }
+  }, [visible, onAnimationComplete]);
+
+  return (
+    <div
+      className={`result-overlay${visible ? " visible" : ""}`}
+      data-testid="result-overlay">
+      <div className="result-message" data-testid="result-message">
+        <strong>{newTitle}</strong> is <strong>{relation}</strong>{" "}
+        <strong>{oldTitle}</strong>
+      </div>
+    </div>
+  );
+}
+
+export default ResultOverlay;

--- a/packages/react-frontend/tests/components/ResultOverlay.test.jsx
+++ b/packages/react-frontend/tests/components/ResultOverlay.test.jsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import ResultOverlay from "../../src/components/ResultOverlay";
+import { describe, test, expect } from "@jest/globals";
+import { jest } from "@jest/globals";
+
+describe("ResultOverlay", () => {
+  test("shows correct message when visible", () => {
+    render(
+      <ResultOverlay
+        visible={true}
+        oldTitle="Card A"
+        newTitle="Card B"
+        relation="Before"
+        onAnimationComplete={() => {}}
+      />
+    );
+    expect(screen.getByTestId("result-overlay")).toHaveClass("visible");
+    expect(screen.getByTestId("result-message").textContent).toContain(
+      "Card B is Before Card A"
+    );
+  });
+
+  test("calls onAnimationComplete after timeout", () => {
+    jest.useFakeTimers();
+    const mockCallback = jest.fn();
+    render(
+      <ResultOverlay
+        visible={true}
+        oldTitle="Card A"
+        newTitle="Card B"
+        relation="After"
+        onAnimationComplete={mockCallback}
+      />
+    );
+    jest.advanceTimersByTime(1500);
+    expect(mockCallback).toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+
+  test("does not show overlay when not visible", () => {
+    render(
+      <ResultOverlay
+        visible={false}
+        oldTitle="Card A"
+        newTitle="Card B"
+        relation="After"
+        onAnimationComplete={() => {}}
+      />
+    );
+    expect(screen.getByTestId("result-overlay")).not.toHaveClass("visible");
+  });
+});


### PR DESCRIPTION
## Developer: Venkata G. Ande

Closes #19 

### Pull Request Summary

Create an animated overlay that appears after a guess, showing "X is Before/After Y" to provide feedback on the correct relationship between cards. Implement smooth animations for overlay and card transitions.

### Modifications

- modified packages/react-frontend/src/App.css
- created packages/react-frontend/src/components/ResultOverlay.jsx
- modified packages/react-frontend/src/pages/GamePage.jsx
- created packages/react-frontend/tests/components/ResultOverlay.test.jsx

### Testing Considerations

I wrote ResultOverlay.test.jsx to test the feature.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our
      [guidelines](https://h4i.notion.site/Git-Commits-Pull-Requests-1-fd22949218fd4b4c976146a0d741b9bf)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

![image](https://github.com/user-attachments/assets/73539ea6-cc94-4b86-a51e-ffa6ace4333b)
