### PR TITLE
Month field added to Schema with seed and test

### DIFF
--- a/packages/express-backend/models/Card.js
+++ b/packages/express-backend/models/Card.js
@@ -19,6 +19,7 @@ dotenv.config({ path: path.join(dirName, "../.env") });
 export const cardSchema = {
   title: { type: String, required: true },
   year: { type: Number, required: true },
+  month: {type: Number, required: true, min: 1, max: 12},
   imageUrl: { type: String, required: true },
   sourceUrl: { type: String, required: true },
   category: { type: String, required: true },
@@ -61,7 +62,8 @@ async function ensureIndexes(collection) {
   await collection.createIndexes([
     { key: { year: 1 }, name: "year_index" },
     { key: { category: 1 }, name: "category_index" },
-    { key: { year: 1, category: 1 }, name: "year_category_index" }
+    { key: { year: 1, category: 1 }, name: "year_category_index" },
+    { key: { month: 1, category: 1 }, name: "month_category_index" }
   ]);
 }
 

--- a/packages/express-backend/models/Card.js
+++ b/packages/express-backend/models/Card.js
@@ -19,7 +19,7 @@ dotenv.config({ path: path.join(dirName, "../.env") });
 export const cardSchema = {
   title: { type: String, required: true },
   year: { type: Number, required: true },
-  month: {type: Number, required: true, min: 1, max: 12},
+  month: { type: Number, required: true, min: 1, max: 12 },
   imageUrl: { type: String, required: true },
   sourceUrl: { type: String, required: true },
   category: { type: String, required: true },

--- a/packages/express-backend/scripts/seed.js
+++ b/packages/express-backend/scripts/seed.js
@@ -38,6 +38,7 @@ export async function seedDatabase() {
       {
         title: "Star Wars: A New Hope",
         year: 1977,
+        month: 5,
         imageUrl:
           "https://upload.wikimedia.org/wikipedia/en/8/82/Leiadeathstar.jpg",
         sourceUrl: "https://www.imdb.com/title/tt0076759/",
@@ -48,6 +49,7 @@ export async function seedDatabase() {
       {
         title: "The Beatles - Abbey Road",
         year: 1969,
+        month: 9,
         imageUrl:
           "https://upload.wikimedia.org/wikipedia/en/4/42/Beatles_-_Abbey_Road.jpg",
         sourceUrl: "https://en.wikipedia.org/wiki/Abbey_Road",
@@ -58,6 +60,7 @@ export async function seedDatabase() {
       {
         title: "Super Mario Bros",
         year: 1985,
+        month: 9,
         imageUrl:
           "https://upload.wikimedia.org/wikipedia/en/0/03/Super_Mario_Bros._box.png",
         sourceUrl: "https://en.wikipedia.org/wiki/Super_Mario_Bros",
@@ -68,6 +71,7 @@ export async function seedDatabase() {
       {
         title: "iPhone First Generation",
         year: 2007,
+        month: 6,
         imageUrl:
           "https://upload.wikimedia.org/wikipedia/commons/thumb/a/ad/IPhone_1st_Gen.svg/800px-IPhone_1st_Gen.svg.png",
         sourceUrl: "https://en.wikipedia.org/wiki/IPhone_(1st_generation)",
@@ -78,6 +82,7 @@ export async function seedDatabase() {
       {
         title: "Mona Lisa",
         year: 1503,
+        month: 10,
         imageUrl:
           "https://upload.wikimedia.org/wikipedia/commons/e/ec/Mona_Lisa%2C_by_Leonardo_da_Vinci%2C_from_C2RMF_retouched.jpg",
         sourceUrl: "https://en.wikipedia.org/wiki/Mona_Lisa",
@@ -88,6 +93,7 @@ export async function seedDatabase() {
       {
         title: "The Shining",
         year: 1980,
+        month: 5,
         imageUrl:
           "https://upload.wikimedia.org/wikipedia/en/b/bb/The_shining_heres_johnny.jpg",
         sourceUrl: "https://www.imdb.com/title/tt0081505/",
@@ -98,6 +104,7 @@ export async function seedDatabase() {
       {
         title: "Michael Jackson - Thriller",
         year: 1982,
+        month: 11,
         imageUrl:
           "https://upload.wikimedia.org/wikipedia/en/5/55/Michael_Jackson_-_Thriller.png",
         sourceUrl: "https://en.wikipedia.org/wiki/Thriller_(album)",
@@ -108,6 +115,7 @@ export async function seedDatabase() {
       {
         title: "World Wide Web",
         year: 1989,
+        month: 3,
         imageUrl:
           "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d1/First_Web_Server.jpg/1920px-First_Web_Server.jpg",
         sourceUrl: "https://en.wikipedia.org/wiki/World_Wide_Web",
@@ -118,6 +126,7 @@ export async function seedDatabase() {
       {
         title: "The Starry Night",
         year: 1889,
+        month: 6,
         imageUrl:
           "https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg/1920px-Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg",
         sourceUrl: "https://en.wikipedia.org/wiki/The_Starry_Night",
@@ -128,6 +137,7 @@ export async function seedDatabase() {
       {
         title: "Minecraft",
         year: 2011,
+        month: 11,
         imageUrl:
           "https://upload.wikimedia.org/wikipedia/en/1/17/Minecraft_explore_landscape.png",
         sourceUrl: "https://en.wikipedia.org/wiki/Minecraft",
@@ -136,6 +146,13 @@ export async function seedDatabase() {
         updatedAt: new Date()
       }
     ];
+
+    // Validate each card has valid month before inserting
+    for (const card of sampleCards) {
+      if (card.month < 1 || card.month > 12) {
+        throw new Error(`Invalid month: ${card.month} in card: ${card.title}`);
+      }
+    }
 
     // Insert sample cards
     const insertResult = await collection.insertMany(sampleCards);

--- a/packages/express-backend/src/services/cardService.js
+++ b/packages/express-backend/src/services/cardService.js
@@ -27,9 +27,11 @@ export async function getRandomCard() {
 /**
  * Process user's before/after guess.
  */
-export async function processGuess(previousYear, currentYear, guess) {
-  // Determine if guess is correct based on year comparison
-  const isAfter = currentYear > previousYear;
+export async function processGuess(previousYear, previousMonth, currentYear, currentMonth, guess) {
+  // Determine if guess is correct based on year and month comparison
+  const isAfter =
+    currentYear > previousYear ||
+    (currentYear === previousYear && currentMonth > previousMonth);
   const correct =
     (guess === "after" && isAfter) || (guess === "before" && !isAfter);
 

--- a/packages/express-backend/src/services/cardService.js
+++ b/packages/express-backend/src/services/cardService.js
@@ -27,7 +27,13 @@ export async function getRandomCard() {
 /**
  * Process user's before/after guess.
  */
-export async function processGuess(previousYear, previousMonth, currentYear, currentMonth, guess) {
+export async function processGuess(
+  previousYear,
+  previousMonth,
+  currentYear,
+  currentMonth,
+  guess
+) {
   // Determine if guess is correct based on year and month comparison
   const isAfter =
     currentYear > previousYear ||

--- a/packages/express-backend/tests/api.test.js
+++ b/packages/express-backend/tests/api.test.js
@@ -36,6 +36,7 @@ describe("API Routes", () => {
       res.json({
         title: "Test Card",
         year: 2000,
+        month: 5,
         imageUrl: "https://example.com/image.jpg",
         sourceUrl: "https://example.com",
         category: "test"
@@ -43,9 +44,16 @@ describe("API Routes", () => {
     });
 
     app.post("/api/cards/guess", (req, res) => {
-      const { previousYear, currentYear, guess } = req.body;
+      const { previousYear, currentYear, previousMonth, currentMonth, guess } =
+        req.body;
 
-      if (previousYear === undefined || currentYear === undefined || !guess) {
+      if (
+        previousYear === undefined ||
+        currentYear === undefined ||
+        previousMonth === undefined ||
+        currentMonth === undefined ||
+        !guess
+      ) {
         return res.status(400).json({ message: "Missing required fields" });
       }
 
@@ -55,7 +63,10 @@ describe("API Routes", () => {
           .json({ message: "Guess must be 'before' or 'after'" });
       }
 
-      const isAfter = currentYear > previousYear;
+      const isAfter =
+        currentYear > previousYear ||
+        (currentYear === previousYear && currentMonth > previousMonth);
+
       const correct =
         (guess === "after" && isAfter) || (guess === "before" && !isAfter);
 
@@ -95,6 +106,8 @@ describe("API Routes", () => {
       const payload = {
         previousYear: 1980,
         currentYear: 1990,
+        previousMonth: 5,
+        currentMonth: 6,
         guess: "after"
       };
 
@@ -109,6 +122,8 @@ describe("API Routes", () => {
       const payload = {
         previousYear: 2000,
         currentYear: 1990,
+        previousMonth: 5,
+        currentMonth: 6,
         guess: "after"
       };
 
@@ -117,6 +132,22 @@ describe("API Routes", () => {
         .send(payload);
       expect(response.status).toBe(200);
       expect(response.body).toHaveProperty("correct", false);
+    });
+
+    test("correct=true when year is same but currentMonth is later", async () => {
+      const payload = {
+        previousYear: 2000,
+        currentYear: 2000,
+        previousMonth: 3,
+        currentMonth: 7,
+        guess: "after"
+      };
+
+      const response = await request(app)
+        .post("/api/cards/guess")
+        .send(payload);
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty("correct", true);
     });
   });
 });

--- a/packages/express-backend/tests/cardService.test.js
+++ b/packages/express-backend/tests/cardService.test.js
@@ -21,6 +21,7 @@ jest.mock("../models/Card", () => ({
           {
             title: "Test Card",
             year: 2000,
+            month: 5,
             imageUrl: "https://example.com/image.jpg",
             sourceUrl: "https://example.com/source",
             category: "test"
@@ -48,6 +49,7 @@ describe("Card Service Tests", () => {
     expect(card).toBeDefined();
     expect(card.title).toBe("Test Card");
     expect(card.year).toBe(2000);
+    expect(card.month).toBe(5);
     expect(getCardsCollection).toHaveBeenCalled();
   });
 
@@ -67,29 +69,54 @@ describe("Card Service Tests", () => {
 
   // Test processGuess
   test("processGuess returns correct=true for correct 'after' guess", async () => {
-    const result = await processGuess(1990, 2000, "after");
+    const result = await processGuess(1990, 6, 2000, 5, "after");
 
     expect(result.correct).toBe(true);
     expect(result.nextCard).toBeDefined();
   });
 
   test("processGuess returns correct=false for incorrect 'after' guess", async () => {
-    const result = await processGuess(2000, 1990, "after");
+    const result = await processGuess(2000, 5, 1990, 6, "after");
 
     expect(result.correct).toBe(false);
     expect(result.nextCard).toBeNull();
   });
 
   test("processGuess returns correct=true for correct 'before' guess", async () => {
-    const result = await processGuess(2000, 1990, "before");
+    const result = await processGuess(2000, 5, 1990, 6, "before");
 
     expect(result.correct).toBe(true);
     expect(result.nextCard).toBeDefined();
   });
 
   test("processGuess returns correct=false for incorrect 'before' guess", async () => {
-    const result = await processGuess(1990, 2000, "before");
+    const result = await processGuess(1990, 6, 2000, 5, "before");
 
+    expect(result.correct).toBe(false);
+    expect(result.nextCard).toBeNull();
+  });
+
+  // Test processGuess with months
+  test("processGuess returns correct=true for correct 'after' when same year", async () => {
+    const result = await processGuess(2000, 6, 2000, 7, "after");
+    expect(result.correct).toBe(true);
+    expect(result.nextCard).toBeDefined();
+  });
+
+  test("processGuess returns correct=false for incorrect 'after' guess when same year", async () => {
+    const result = await processGuess(2000, 6, 2000, 5, "after");
+    expect(result.correct).toBe(false);
+    expect(result.nextCard).toBeNull();
+  });
+
+  test("processGuess returns correct=true for correct 'before' guess when same year", async () => {
+    const result = await processGuess(2000, 5, 2000, 2, "before");
+    expect(result.correct).toBe(true);
+    expect(result.nextCard).toBeDefined();
+  });
+
+  test("processGuess returns correct=false for incorrect 'before' guess when same year", async () => {
+    const result = await processGuess(2000, 6, 2000, 10, "before");
     expect(result.correct).toBe(false);
     expect(result.nextCard).toBeNull();
   });

--- a/packages/express-backend/tests/mongodb-query.test.js
+++ b/packages/express-backend/tests/mongodb-query.test.js
@@ -66,7 +66,7 @@ describe("MongoDB Query Performance", () => {
 
     // Execute query with explain
     const explanation = await collection
-      .find({ month:5, category: "movie" })
+      .find({ month: 5, category: "movie" })
       .explain("executionStats");
 
     // Verify execution plan

--- a/packages/express-backend/tests/mongodb-query.test.js
+++ b/packages/express-backend/tests/mongodb-query.test.js
@@ -55,4 +55,34 @@ describe("MongoDB Query Performance", () => {
     // Verify reasonable execution time
     expect(explanation.executionStats.executionTimeMillis).toBeLessThan(100);
   });
+
+  test("month-based queries use index", async () => {
+    // Skip test if no documents exist
+    const count = await collection.countDocuments();
+    if (count === 0) {
+      console.warn("Skipping test: No documents in collection");
+      return;
+    }
+
+    // Execute query with explain
+    const explanation = await collection
+      .find({ month:5, category: "movie" })
+      .explain("executionStats");
+
+    // Verify execution plan
+    const executionStages = explanation.executionStats.executionStages;
+
+    // Check if IXSCAN exists in the execution stages
+    function hasIndexScan(stages) {
+      if (stages.stage === "IXSCAN") return true;
+      if (stages.inputStage && stages.inputStage.stage === "IXSCAN")
+        return true;
+      return false;
+    }
+
+    expect(hasIndexScan(executionStages)).toBe(true);
+
+    // Verify reasonable execution time
+    expect(explanation.executionStats.executionTimeMillis).toBeLessThan(100);
+  });
 });

--- a/packages/express-backend/tests/seed.test.js
+++ b/packages/express-backend/tests/seed.test.js
@@ -42,6 +42,7 @@ describe("Seed script", () => {
     const sampleCard = {
       title: "Test Card",
       year: 2000,
+      month: 5,
       imageUrl: "https://example.com/image.jpg",
       sourceUrl: "https://example.com",
       category: "test",
@@ -59,6 +60,7 @@ describe("Seed script", () => {
     const retrievedCard = cards[0];
     expect(retrievedCard).toHaveProperty("title", "Test Card");
     expect(retrievedCard).toHaveProperty("year", 2000);
+    expect(retrievedCard).toHaveProperty("month", 5);
     expect(retrievedCard).toHaveProperty("category", "test");
   });
 });


### PR DESCRIPTION
## Developer: Sean Griffin

Closes #14 

### Pull Request Summary

Update Card.js to have a month field, also updated seed.js and tests to work with new month field. processGuess also now compares month if years are the same.

### Modifications
packages/express-backend/src/services/cardService.js 
* now compares between both year and month
packages/express-backend/scripts/seed.js
* now seeds example cards with months
packages/express-backend/models/Card.js
* Card model now has a month field from 1-12
Test files that use cards now have additional tests for months, or now include month fields

### Testing Considerations

Confirm all compare test cards works, nothing visible in frontend yet

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our
      [guidelines](https://h4i.notion.site/Git-Commits-Pull-Requests-1-fd22949218fd4b4c976146a0d741b9bf)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast
<img width="548" alt="image" src="https://github.com/user-attachments/assets/2cab7888-e06b-47f6-bb31-02fc8b72f6e1" />
<img width="662" alt="image" src="https://github.com/user-attachments/assets/1ccdeea2-b2af-41ea-98f0-d9364d21a228" />

