### PR TITLE
Issue27

### DIFF
--- a/packages/react-frontend/src/App.css
+++ b/packages/react-frontend/src/App.css
@@ -141,7 +141,7 @@ main {
   object-fit: contain;
 }
 
-.guess-buttons {
+.current-card .guess-buttons {
   display: flex;
   gap: 1rem;
   justify-content: center;
@@ -372,49 +372,165 @@ footer {
 
 /* Game Page Styling */
 
+.header-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0;
+  margin: 0;
+}
+
+.desktop-only {
+  padding: 0;
+  margin: 0;
+  height: auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  box-sizing: border-box;
+}
+
+.main-content {
+  padding: 0;
+  margin: 0;
+  box-sizing: border-box;
+}
+
 .game-page {
+  position: relative;
   text-align: center;
-  padding: 2rem 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  height: 100vh;
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  box-sizing: border-box;
 }
 
 .cards-container {
   display: flex;
-  gap: 1rem;
-  justify-content: center;
-  margin-bottom: 2rem;
+  justify-content: space-between;
+  align-items: stretch;
+  gap: 0;
+  height: 100vh;
+  width: 100vw;
+  padding: 0;
+  margin: 0;
+  box-sizing: border-box;
+}
+
+.cards-container.side-by-side {
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .cards-container.stacked {
   flex-direction: column;
 }
 
-.cards-container.side-by-side {
-  flex-direction: row;
+.cards-container.side-by-side .reference-card {
+  order: 1 !important;
+}
+
+.cards-container.side-by-side .current-card {
+  order: 2 !important;
+}
+
+.cards-container.stacked .reference-card {
+  order: 2;
+}
+
+.cards-container.stacked .current-card {
+  order: 1;
 }
 
 .card {
+  flex: 1 1 100%;
+  height: 100%;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   background-color: white;
-  border-radius: 0.5rem;
-  box-shadow: var(--card-shadow);
-  padding: 1rem;
+  border-radius: 0;
+  box-shadow: none;
+  padding: 0;
   text-align: center;
-  width: 100%;
-  max-width: 300px;
-  height: 300px;
-  cursor: pointer;
-  transition:
-    transform 0.2s,
-    box-shadow 0.2s;
+  overflow: hidden;
+  position: relative;
 }
 
 .card:hover {
-  transform: scale(1.05);
-  box-shadow:
-    0 6px 10px -1px rgba(0, 0, 0, 0.2),
-    0 4px 6px -2px rgba(0, 0, 0, 0.2);
+  transform: scale(1.02);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+}
+
+.card-enter {
+  transform: translateX(100%);
+}
+
+.card-enter-active {
+  transform: translateX(0);
+}
+
+.card-exit {
+  transform: translateX(0);
+}
+
+.card-exit-active {
+  transform: translateX(-100%);
+}
+
+.card-title {
+  font-size: 1.2rem;
+  font-weight: bold;
+  color: var(--primary-color);
+  margin-bottom: 0.5rem 0;
+  margin-top: 0;
+}
+
+.card-date {
+  font-size: 1rem;
+  color: var(--secondary-color);
+  margin-bottom: 0.5rem;
+}
+
+.card-image {
+  flex-grow: 1;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+}
+
+.card-image img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  max-height: none !important;
+}
+
+.card-source {
+  position: absolute;
+  bottom: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--background-color);
+  opacity: 0.8rem;
+}
+
+.card-source.left {
+  left: 0.5rem; /* Align to the bottom left */
+}
+
+.card-source.right {
+  right: 0.5rem; /* Align to the bottom right */
+  text-align: right;
 }
 
 .spacer {
@@ -432,22 +548,85 @@ footer {
   margin-top: auto;
 }
 
+.game-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 1rem 0;
+  pointer-events: none;
+  z-index: 10;
+}
+
+.game-title {
+  font-size: 2.5rem;
+  font-weight: bold;
+  color: white;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+  margin: 0;
+  padding: 0;
+}
+
 .score-display {
   font-size: 1.2rem;
-  margin-bottom: 1.5rem;
+  font-weight: bold;
+  color: white;
+  text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+  background-color: rgba(0, 0, 0, 0.5);
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.guess-buttons {
+  position: absolute;
+  top: 25%;
+  left: 33%;
+  transform: translateX(-50%, -50%);
+  display: flex;
+  gap: 1rem;
+  z-index: 10;
+}
+
+.current-card .before-button,
+.current-card .after-button {
+  padding: 0.75rem 2rem;
+  font-size: 1.2rem;
+  background-color: var(--primary-color);
+  color: white;
+  border: none;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: background-color 0.2s, transform 0.2s;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.current-card .before-button:hover,
+.current-card .after-button:hover {
+  background-color: #1d4ed8;
+  transform: scale(1.05);
+}
+
+.current-card .before-button:active,
+.current-card .after-button:active {
+  transform: scale(0.95);
 }
 
 .back-home-button {
-  padding: 0.75rem 1.5rem;
-  font-size: 1rem;
+  font-weight: 100;
+  font-size: 0.9rem;
   background-color: var(--accent-color);
-  color: white;
+  color: black !important;
   border: none;
-  border-radius: 0.25rem;
-  cursor: pointer;
-  transition:
-    background-color 0.2s,
-    transform 0.2s;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  width: auto;
+  max-width: 120px;
+  max-height: 50px;
+  height: auto;
 }
 
 .back-home-button:hover {
@@ -457,6 +636,26 @@ footer {
 
 .back-home-button:active {
   transform: scale(0.95);
+}
+
+@media (max-width: 768px) {
+  .cards-container {
+    flex-direction: column;
+  }
+
+  .card {
+    flex: 1 1 auto;
+    width: 100%;
+    height: 50%;
+  }
+}
+
+@media (min-width: 769px) {
+  .cards-container.side-by-side {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+  }
 }
 
 /* Login Form Styles */

--- a/packages/react-frontend/src/App.css
+++ b/packages/react-frontend/src/App.css
@@ -414,7 +414,7 @@ footer {
   display: flex;
   justify-content: space-between;
   align-items: stretch;
-  gap: 0;
+  gap: 1rem;
   height: 100vh;
   width: 100vw;
   padding: 0;
@@ -641,6 +641,7 @@ footer {
 @media (max-width: 768px) {
   .cards-container {
     flex-direction: column;
+    gap: 0.5rem;
   }
 
   .card {

--- a/packages/react-frontend/src/components/BottomNav.jsx
+++ b/packages/react-frontend/src/components/BottomNav.jsx
@@ -28,12 +28,12 @@ function BottomNav() {
       <div className="container">
         <div className="nav-items">
           <button
-              className="back-home-button"
-              onClick={() => navigate("/")}
-              style={{ marginTop: "20px" }}>
-              Back to Home
+            className="back-home-button"
+            onClick={() => navigate("/")}
+            style={{ marginTop: "20px" }}>
+            Back to Home
           </button>
-          
+
           {/* Left: High Score */}
           <div className="high-score">High: {highscore}</div>
 

--- a/packages/react-frontend/src/components/BottomNav.jsx
+++ b/packages/react-frontend/src/components/BottomNav.jsx
@@ -27,6 +27,13 @@ function BottomNav() {
     <nav className="mobile-only bottom-nav">
       <div className="container">
         <div className="nav-items">
+          <button
+              className="back-home-button"
+              onClick={() => navigate("/")}
+              style={{ marginTop: "20px" }}>
+              Back to Home
+          </button>
+          
           {/* Left: High Score */}
           <div className="high-score">High: {highscore}</div>
 

--- a/packages/react-frontend/src/components/Card.jsx
+++ b/packages/react-frontend/src/components/Card.jsx
@@ -46,7 +46,8 @@ function Card({ title, imageUrl, year, month, isReference, children }) {
     <div className={`card ${isReference ? "reference-card" : "current-card"}`}>
       <h3 className="card-title">{title}</h3>
       <div className="card-date">
-        {isReference ? `${month}/${year}` : "?"} {/* Display date only for reference cards */}
+        {isReference ? `${month}/${year}` : "?"}{" "}
+        {/* Display date only for reference cards */}
       </div>
       <div className="card-image">
         <img src={imageUrl} alt={title} />

--- a/packages/react-frontend/src/components/Card.jsx
+++ b/packages/react-frontend/src/components/Card.jsx
@@ -1,3 +1,5 @@
+import React from "react";
+
 /**
  * Card component for displaying artifact info.
  * @param {Object} props
@@ -27,15 +29,34 @@ function formatDate(month, year) {
   const monthName = monthNames[month - 1] || "";
   return `${monthName} ${year}`;
 }
+function Card({ title, imageUrl, year, month, isReference, children }) {
+  // Extract the domain name from the imageUrl
+  const getSourceFromUrl = (url) => {
+    try {
+      const { hostname } = new URL(url);
+      return hostname.replace("www.", ""); // Remove "www." for cleaner display
+    } catch {
+      return "Unknown Source"; // Fallback if the URL is invalid
+    }
+  };
 
-const Card = ({ title, imageUrl, year, month, isReference }) => (
-  <div className="card">
-    <h2>{title}</h2>
-    {isReference && <div className="card-date">{formatDate(month, year)}</div>}
-    <div className="placeholder-image">
-      {imageUrl ? <img src={imageUrl} alt={title} /> : "No Image"}
+  const source = getSourceFromUrl(imageUrl);
+
+  return (
+    <div className={`card ${isReference ? "reference-card" : "current-card"}`}>
+      <h3 className="card-title">{title}</h3>
+      <div className="card-date">
+        {isReference ? `${month}/${year}` : "?"} {/* Display date only for reference cards */}
+      </div>
+      <div className="card-image">
+        <img src={imageUrl} alt={title} />
+      </div>
+      {children}
+      <div className={`card-source ${isReference ? "left" : "right"}`}>
+        Source: {source}
+      </div>
     </div>
-  </div>
-);
+  );
+}
 
 export default Card;

--- a/packages/react-frontend/src/components/Header.jsx
+++ b/packages/react-frontend/src/components/Header.jsx
@@ -41,6 +41,11 @@ function Header() {
     <header className="desktop-only">
       <div className="container">
         <nav className="header-nav">
+          <button
+            className="back-home-button"
+            onClick={() => navigate("/")}>
+            Back to Home
+          </button>
           {/* Left: High Score */}
           <div className="high-score">High Score: {highscore}</div>
 

--- a/packages/react-frontend/src/components/Header.jsx
+++ b/packages/react-frontend/src/components/Header.jsx
@@ -41,9 +41,7 @@ function Header() {
     <header className="desktop-only">
       <div className="container">
         <nav className="header-nav">
-          <button
-            className="back-home-button"
-            onClick={() => navigate("/")}>
+          <button className="back-home-button" onClick={() => navigate("/")}>
             Back to Home
           </button>
           {/* Left: High Score */}

--- a/packages/react-frontend/src/pages/GamePage.jsx
+++ b/packages/react-frontend/src/pages/GamePage.jsx
@@ -156,8 +156,7 @@ function GamePage() {
               imageUrl={currentCard?.imageUrl}
               year={currentCard?.year}
               month={currentCard?.month}
-              isReference={false}
-            >
+              isReference={false}>
               <div className="guess-buttons">
                 <button
                   className="before-button"

--- a/packages/react-frontend/src/pages/GamePage.jsx
+++ b/packages/react-frontend/src/pages/GamePage.jsx
@@ -149,46 +149,41 @@ function GamePage() {
 
           <div
             className={`cards-container ${isMobile ? "stacked" : "side-by-side"}`}>
+            {/* Current Card (guess card) */}
+            <Card
+              className="current-card"
+              title={currentCard?.title}
+              imageUrl={currentCard?.imageUrl}
+              year={currentCard?.year}
+              month={currentCard?.month}
+              isReference={false}
+            >
+              <div className="guess-buttons">
+                <button
+                  className="before-button"
+                  onClick={() => handleGuess("before")}
+                  disabled={isLoading}>
+                  Before
+                </button>
+                <button
+                  className="after-button"
+                  onClick={() => handleGuess("after")}
+                  disabled={isLoading}>
+                  After
+                </button>
+              </div>
+            </Card>
+
             {/* Reference Card */}
             <Card
+              className="reference-card"
               title={referenceCard?.title}
               imageUrl={referenceCard?.imageUrl}
               year={referenceCard?.year}
               month={referenceCard?.month}
               isReference={true}
             />
-
-            {/* Current Card (guess card) */}
-            <Card
-              title={currentCard?.title}
-              imageUrl={currentCard?.imageUrl}
-              year={currentCard?.year}
-              month={currentCard?.month}
-              isReference={false}
-            />
           </div>
-
-          <div className="guess-buttons">
-            <button
-              className="before-button"
-              onClick={() => handleGuess("before")}
-              disabled={isLoading}>
-              Before
-            </button>
-            <button
-              className="after-button"
-              onClick={() => handleGuess("after")}
-              disabled={isLoading}>
-              After
-            </button>
-          </div>
-
-          <button
-            className="back-home-button"
-            onClick={() => navigate("/")}
-            style={{ marginTop: "20px" }}>
-            Back to Home
-          </button>
         </div>
         <ResultOverlay
           visible={showOverlay}


### PR DESCRIPTION
## Developer: Yenny Ma

Closes #27

### Pull Request Summary

Made the game cards larger and more prominent. Repositioned buttons to make room for cards.

### Modifications

`before-or-after/packages/react-frontend/src/App.css`

- Changed the styling of buttons, cards, containers, and nav bar
- Changed position of Before/After/Home buttons
- Enlarged card dimensions
- Added gap between cards
- Made it so that current card appears on top of reference card in mobile view

`before-or-after/packages/react-frontend/src/components/Card.jsx`

- Turned Card constant into a function
- Added source attribution at bottom corner of card image

`before-or-after/packages/react-frontend/src/pages/GamePage.jsx`

- Removed Home button and relocated to nav bar

`before-or-after/packages/react-frontend/src/components/Header.jsx`

- Added Home button to nav bar to reduce spacing used up by extra containers

### Testing Considerations

On the game page:

- [ ] The current card should always appear on the right in desktop view
- [ ] The current card should always appear on top in mobile view
- [ ] The cards should present a much larger appearance and take up the width of the screen
- [ ] The Home button should appear on the left of the nav bar
- [ ] The source of the current card should appear on the bottom right of its image
- [ ] The source of the reference card should appear on the bottom left of its image

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our
      [guidelines](https://h4i.notion.site/Git-Commits-Pull-Requests-1-fd22949218fd4b4c976146a0d741b9bf)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

![image](https://github.com/user-attachments/assets/269d8948-515e-4e18-b49e-3cdbe0a9e2f7)

(Scroll down to see the source attribution)

![image](https://github.com/user-attachments/assets/0094baf1-26b0-4f48-b066-3dbb54719c36)
