### PR TITLE
fix: Fix Guest Score Migration on Login

### DIFF
--- a/packages/react-frontend/src/context/AuthContext.jsx
+++ b/packages/react-frontend/src/context/AuthContext.jsx
@@ -8,6 +8,7 @@ import {
   isGuestMode as checkGuestMode,
   clearGuestMode
 } from "../utils/authUtils";
+import { useGame } from "./GameContext";
 
 // Create auth context
 const AuthContext = createContext();
@@ -17,6 +18,8 @@ export function AuthProvider({ children }) {
   const [isGuest, setIsGuest] = useState(checkGuestMode());
   const [user, setUser] = useState(getCurrentUser());
   const [isLoading, setIsLoading] = useState(true);
+
+  const { migrateGuestScores } = useGame();
 
   // Check auth status on mount and when localStorage changes
   useEffect(() => {
@@ -45,6 +48,7 @@ export function AuthProvider({ children }) {
     setIsGuest(false);
     clearGuestMode(); // Clear guest mode when logging in
     setUser(getCurrentUser());
+    migrateGuestScores();
   };
 
   // Logout function


### PR DESCRIPTION
## Developer: Venkata G. Ande

Closes #44

### Pull Request Summary

Fix bug where guest high score doesn't persist after login. Guest user scores migrate only if guest score is higher.

### Modifications

```packages/react-frontend/src/context/AuthContext.jsx```

### Testing Considerations

I have not actually tested the fix.

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our
      [guidelines](https://h4i.notion.site/Git-Commits-Pull-Requests-1-fd22949218fd4b4c976146a0d741b9bf)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

![image](https://github.com/user-attachments/assets/20dc89a1-46bc-4db8-bae6-d8a8f2968db2)
