### PR TITLE
Loss gif admin setup

### DIFF
--- a/packages/express-backend/scripts/createLossGifs.js
+++ b/packages/express-backend/scripts/createLossGifs.js
@@ -1,0 +1,112 @@
+import { getLossGifsCollection } from "../models/LossGif.js";
+import dotenv from "dotenv";
+import path from "path";
+import { fileURLToPath } from "url";
+
+let dirName;
+try {
+  dirName = path.dirname(fileURLToPath(import.meta.url));
+} catch {
+  dirName = process.cwd();
+}
+
+dotenv.config({ path: path.join(dirName, "../.env") });
+
+/**
+ * Initialize 5 fixed loss GIF categories with score thresholds.
+ * Create records only when database empty to prevent duplicates.
+ */
+async function createLossGifs() {
+  let client;
+
+  try {
+    const { client: dbClient, collection } = await getLossGifsCollection();
+    client = dbClient;
+
+    // Check if records already exist
+    const existingCount = await collection.countDocuments();
+    if (existingCount > 0) {
+      console.log(
+        `Found ${existingCount} existing loss GIF records. Skipping creation.`
+      );
+      return;
+    }
+
+    // Define 5 fixed loss GIF categories with score thresholds
+    const lossGifCategories = [
+      {
+        category: "Terrible",
+        scoreRange: "< 2",
+        streakThreshold: 2,
+        imageUrl: "https://placeholder-gif-url.com/terrible.gif",
+        thumbnailUrl: "https://placeholder-gif-url.com/terrible-thumb.gif",
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        category: "Frustrated",
+        scoreRange: "2 - 4",
+        streakThreshold: 5,
+        imageUrl: "https://placeholder-gif-url.com/frustrated.gif",
+        thumbnailUrl: "https://placeholder-gif-url.com/frustrated-thumb.gif",
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        category: "Decent",
+        scoreRange: "5 - 7",
+        streakThreshold: 8,
+        imageUrl: "https://placeholder-gif-url.com/decent.gif",
+        thumbnailUrl: "https://placeholder-gif-url.com/decent-thumb.gif",
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        category: "Satisfied",
+        scoreRange: "8 - 11",
+        streakThreshold: 12,
+        imageUrl: "https://placeholder-gif-url.com/satisfied.gif",
+        thumbnailUrl: "https://placeholder-gif-url.com/satisfied-thumb.gif",
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
+        category: "Ecstatic",
+        scoreRange: "≥ 12",
+        streakThreshold: 999999, // High threshold for unlimited range
+        imageUrl: "https://placeholder-gif-url.com/ecstatic.gif",
+        thumbnailUrl: "https://placeholder-gif-url.com/ecstatic-thumb.gif",
+        createdAt: new Date(),
+        updatedAt: new Date()
+      }
+    ];
+
+    // Insert all categories in single operation
+    const result = await collection.insertMany(lossGifCategories);
+    console.log(
+      `Created ${result.insertedCount} loss GIF categories successfully`
+    );
+
+    // Display created categories
+    lossGifCategories.forEach((category, index) => {
+      console.log(
+        `  ${index + 1}. ${category.category} (threshold: ${category.streakThreshold})`
+      );
+    });
+  } catch (error) {
+    console.error("Loss GIF creation error:", error);
+    process.exit(1);
+  } finally {
+    if (client) await client.close();
+  }
+}
+
+// Execute script when run directly
+createLossGifs()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error("Script execution failed:", error);
+    process.exit(1);
+  });

--- a/packages/express-backend/server.js
+++ b/packages/express-backend/server.js
@@ -556,13 +556,16 @@ const server = http.createServer(async (req, res) => {
         path.startsWith("/api/admin/loss-gifs/") &&
         req.method === "PUT"
       ) {
+        mockReq.fileData = fileData;
         await adminLossGifsHandler(mockReq, mockRes);
       } else if (
         path.startsWith("/api/admin/loss-gifs/") &&
         req.method === "DELETE"
       ) {
+        mockReq.fileData = fileData;
         await adminLossGifsHandler(mockReq, mockRes);
       } else if (path === "/api/admin/loss-gifs") {
+        mockReq.fileData = fileData;
         await adminLossGifsHandler(mockReq, mockRes);
       } else {
         mockRes.status(404).send("Not Found");

--- a/packages/react-frontend/src/components/LossGifCard.jsx
+++ b/packages/react-frontend/src/components/LossGifCard.jsx
@@ -2,7 +2,7 @@ import { forwardRef } from "react";
 
 /**
  * Display loss GIF card with edit functionality.
- * Mirrors AdminCard structure for consistency.
+ * Show category name and score range from database fields.
  */
 const LossGifCard = forwardRef(({ lossGif, onEdit }, ref) => {
   return (
@@ -35,7 +35,7 @@ const LossGifCard = forwardRef(({ lossGif, onEdit }, ref) => {
         </div>
       </div>
       <div className="admin-card-info">
-        <span className="admin-card-category">{lossGif.category}</span>
+        <span className="admin-card-category">Score: {lossGif.scoreRange}</span>
         <span className="admin-card-year">
           Threshold: {lossGif.streakThreshold}
         </span>

--- a/packages/react-frontend/src/components/LossGifForm.jsx
+++ b/packages/react-frontend/src/components/LossGifForm.jsx
@@ -9,8 +9,8 @@ import ImageUpload from "./ImageUpload";
 function LossGifForm({ lossGif, onClose }) {
   const [formData, setFormData] = useState({
     category: lossGif.category || "",
-    streakThreshold: lossGif.streakThreshold || "",
-    imageUrl: lossGif.imageUrl || ""
+    scoreRange: lossGif.scoreRange || "",
+    streakThreshold: lossGif.streakThreshold || ""
   });
 
   const [selectedFile, setSelectedFile] = useState(null);
@@ -23,7 +23,8 @@ function LossGifForm({ lossGif, onClose }) {
    */
   const handleInputChange = (e) => {
     const { name, value } = e.target;
-    setFormData((prev) => ({ ...prev, [name]: value }));
+    const newFormData = { ...formData, [name]: value };
+    setFormData(newFormData);
   };
 
   /**
@@ -50,30 +51,31 @@ function LossGifForm({ lossGif, onClose }) {
     setUploadError("");
 
     // Validate required fields with proper trimming
-    const { category, streakThreshold, imageUrl } = formData;
+    const { category, scoreRange, streakThreshold } = formData;
     const trimmedCategory = (category || "").trim();
-    const trimmedImageUrl = (imageUrl || "").trim();
+    const trimmedScoreRange = (scoreRange || "").trim();
 
-    if (!trimmedCategory || !streakThreshold || !trimmedImageUrl) {
-      setUploadError("All fields are required");
+    if (!trimmedCategory || !streakThreshold || !trimmedScoreRange) {
+      const errorMsg = "All fields are required";
+      setUploadError(errorMsg);
       return;
     }
 
-    updateMutation.mutate(
-      {
-        lossGifId: lossGif._id,
-        formData,
-        selectedFile
+    // Call mutation with payload
+    const mutationPayload = {
+      lossGifId: lossGif._id,
+      formData,
+      selectedFile
+    };
+
+    updateMutation.mutate(mutationPayload, {
+      onSuccess: () => {
+        onClose();
       },
-      {
-        onSuccess: () => {
-          onClose();
-        },
-        onError: (error) => {
-          setUploadError(error.message || "Failed to update loss GIF");
-        }
+      onError: (error) => {
+        setUploadError(error.message || "Failed to update loss GIF");
       }
-    );
+    });
   };
 
   return (
@@ -94,6 +96,19 @@ function LossGifForm({ lossGif, onClose }) {
         </div>
 
         <div className="form-group">
+          <label htmlFor="scoreRange">Score Range</label>
+          <input
+            type="text"
+            id="scoreRange"
+            name="scoreRange"
+            value={formData.scoreRange}
+            onChange={handleInputChange}
+            placeholder="< 2, 2 - 4, ≥ 12, etc."
+            required
+          />
+        </div>
+
+        <div className="form-group">
           <label htmlFor="streakThreshold">Streak Threshold</label>
           <input
             type="number"
@@ -102,19 +117,6 @@ function LossGifForm({ lossGif, onClose }) {
             min="0"
             value={formData.streakThreshold}
             onChange={handleInputChange}
-            required
-          />
-        </div>
-
-        <div className="form-group">
-          <label htmlFor="imageUrl">Current Image URL</label>
-          <input
-            type="url"
-            id="imageUrl"
-            name="imageUrl"
-            value={formData.imageUrl}
-            onChange={handleInputChange}
-            placeholder="https://..."
             required
           />
         </div>

--- a/packages/react-frontend/src/hooks/useLossGifs.js
+++ b/packages/react-frontend/src/hooks/useLossGifs.js
@@ -52,8 +52,9 @@ export const useUpdateLossGif = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ lossGifId, formData, selectedFile }) =>
-      updateLossGif(lossGifId, formData, selectedFile),
+    mutationFn: ({ lossGifId, formData, selectedFile }) => {
+      return updateLossGif(lossGifId, formData, selectedFile);
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["admin-loss-gifs"] });
     }

--- a/packages/react-frontend/src/pages/AdminDashboard.jsx
+++ b/packages/react-frontend/src/pages/AdminDashboard.jsx
@@ -179,7 +179,7 @@ function AdminDashboard() {
             <h1>Admin Dashboard</h1>
           </header>
 
-          {/* Loss GIF Management Section */}
+          {/* Loss GIF Management Section - Fixed Categories */}
           <section style={{ marginBottom: "3rem" }}>
             <h2 style={{ marginBottom: "2rem", color: "var(--text-color)" }}>
               Loss GIF Management
@@ -205,13 +205,29 @@ function AdminDashboard() {
               </div>
             ) : (
               <div className="admin-cards-grid">
-                {lossGifs?.map((lossGif) => (
-                  <LossGifCard
-                    key={lossGif._id}
-                    lossGif={lossGif}
-                    onEdit={handleEditLossGif}
-                  />
-                ))}
+                {lossGifs
+                  ?.sort((a, b) => a.streakThreshold - b.streakThreshold)
+                  .map((lossGif) => (
+                    <LossGifCard
+                      key={lossGif._id}
+                      lossGif={lossGif}
+                      onEdit={handleEditLossGif}
+                    />
+                  ))}
+              </div>
+            )}
+
+            {/* Display warning when not exactly 5 categories */}
+            {lossGifs && lossGifs.length !== 5 && (
+              <div
+                style={{
+                  textAlign: "center",
+                  color: "var(--before-red)",
+                  marginTop: "1rem",
+                  fontSize: "0.9rem"
+                }}>
+                Expected 5 loss GIF categories, found {lossGifs.length}. Run
+                initialization script.
               </div>
             )}
           </section>

--- a/packages/react-frontend/src/utils/apiClient.js
+++ b/packages/react-frontend/src/utils/apiClient.js
@@ -12,15 +12,7 @@ export async function apiRequest(endpoint, options = {}) {
     ? endpoint
     : `/${endpoint}`;
 
-  // Check if we're in production
-  const isProduction = import.meta.env.PROD;
-
-  const url =
-    isProduction && API_URL
-      ? `${API_URL}${normalizedEndpoint}`
-      : normalizedEndpoint;
-
-  console.log(`Making API request to: ${url}`);
+  const url = API_URL ? `${API_URL}${normalizedEndpoint}` : normalizedEndpoint;
 
   // Only set Content-Type for non-FormData requests
   const headers = {};
@@ -38,30 +30,16 @@ export async function apiRequest(endpoint, options = {}) {
     headers
   };
 
-  try {
-    const response = await fetch(url, config);
+  const response = await fetch(url, config);
 
-    if (!response.ok) {
-      let errorMessage = `Request failed with status ${response.status}`;
-
-      // Try to parse error message from response
-      try {
-        const errorData = await response.json();
-        if (errorData.message) {
-          errorMessage = errorData.message;
-        }
-      } catch {
-        // Unable to parse JSON, use default error message
-      }
-
-      throw new Error(errorMessage);
-    }
-
-    return await response.json();
-  } catch (error) {
-    console.error(`API request error for ${endpoint}:`, error);
-    throw error;
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(
+      errorData.message || `Request failed with status ${response.status}`
+    );
   }
+
+  return await response.json();
 }
 
 /**

--- a/packages/react-frontend/tests/components/LossGifCard.test.js
+++ b/packages/react-frontend/tests/components/LossGifCard.test.js
@@ -13,6 +13,7 @@ describe("LossGifCard component", () => {
       _id: "test-id",
       category: "frustrated",
       streakThreshold: 5,
+      scoreRange: "2 - 4",
       imageUrl: "https://example.com/frustrated.gif",
       thumbnailUrl: "https://example.com/frustrated-thumb.gif"
     };
@@ -32,11 +33,9 @@ describe("LossGifCard component", () => {
     expect(screen.getByText("Threshold: 5")).toBeInTheDocument();
   });
 
-  test("shows category in card info section", () => {
+  test("shows score range in card info section", () => {
     render(<LossGifCard lossGif={mockLossGif} onEdit={mockOnEdit} />);
-
-    const categoryElements = screen.getAllByText("frustrated");
-    expect(categoryElements.length).toBeGreaterThan(1); // Title + info section
+    expect(screen.getByText("Score: 2 - 4")).toBeInTheDocument();
   });
 
   test("displays thumbnail image with correct attributes", () => {


### PR DESCRIPTION
## Developer: Kevin Rutledge

Closes #69 

### Pull Request Summary

Implement complete loss GIF management system with fixed categories, image upload support, and proper test coverage.

### Modifications

**Backend Changes:**
- `api/admin/loss-gifs.js` - Added image upload handling, scoreRange field validation, removed POST/DELETE operations
- `scripts/createLossGifs.js` - New script to initialize 5 fixed loss GIF categories with placeholder URLs
- `services/imageProcessor.js` - Added GIF support with static thumbnail generation
- `services/s3Service.js` - Added `uploadLossGifImagePair` function for dedicated loss GIF folders
- `server.js` - Added fileData parsing for loss GIF endpoints

**Frontend Changes:**
- `components/LossGifCard.jsx` - Updated to display scoreRange instead of duplicate category
- `components/LossGifForm.jsx` - Added scoreRange field, removed imageUrl field, improved validation
- `hooks/useLossGifs.js` - Fixed mutation function structure
- `pages/AdminDashboard.jsx` - Added sorting by threshold, category count warning
- `utils/apiClient.js` - Simplified error handling and removed debug logging

**Test Updates:**
- `tests/components/LossGifCard.test.js` - Added scoreRange field, fixed category expectations
- `tests/components/LossGifForm.test.jsx` - Updated for new form structure, added error handling safety checks
- `tests/loss-gif-admin.test.js` - Removed unsupported CRUD operations, added scoreRange validation

### Testing Considerations

**Verified functionality:**
- Loss GIF listing and sorting by threshold
- Image upload with GIF support and WebP conversion
- Form validation for required fields (category, scoreRange, streakThreshold)
- Error handling for missing files and invalid data

### Pull Request Checklist

- [ ] Code is neat, readable, and works
- [ ] Comments are appropriate
- [ ] The commit messages follows our
      [guidelines](https://h4i.notion.site/Git-Commits-Pull-Requests-1-fd22949218fd4b4c976146a0d741b9bf)
- [ ] The developer name is specified
- [ ] The summary is completed
- [ ] Assign reviewers

### Screenshots/Screencast

![image](https://github.com/user-attachments/assets/460843b4-c63b-4eab-b3e7-e0e123694af6)

![image](https://github.com/user-attachments/assets/a3223458-0d5a-4551-98d3-5815b8a1cc22)
